### PR TITLE
change "Related trait(s) or use(s) in biotechnology" to "Modified traits"

### DIFF
--- a/app/views/search/search-filters/bch-left-menu-filters.json
+++ b/app/views/search/search-filters/bch-left-menu-filters.json
@@ -334,7 +334,7 @@
 		{
 			"type": "thesaurus",
 			"term": "dnaSequenceTraits",
-			"title": "Modified trait",
+			"title": "Modified traits",
 			"field": "trait_ss",
 			"relatedField":"trait_REL_ss"
 		},

--- a/app/views/search/search-filters/bch-left-menu-filters.json
+++ b/app/views/search/search-filters/bch-left-menu-filters.json
@@ -266,7 +266,7 @@
 		{
 			"type": "thesaurus",
 			"term": "dnaSequenceTraits",
-			"title": "Related trait(s) or use(s) in biotechnology",
+			"title": "Modified traits",
 			"field": "lmoTraits_ss",
 			"relatedField":"lmoTraits_REL_ss"
 		},
@@ -425,7 +425,7 @@
 		{
 			"type": "thesaurus",
 			"term": "dnaSequenceTraits",
-			"title": "Related trait(s) or use(s) in biotechnology",
+			"title": "Modified traits",
 			"field": "lmoTraits_ss",
 			"relatedField":"lmoTraits_REL_ss"
 		},


### PR DESCRIPTION
DEVDESK-519:
Sub-filter in Search needs also to be in plural: Modified traits

DEVDESK-531
BCH-RAs (national and reference) - change sub-filter "Related trait(s) or use(s) in biotechnology" to "Modified traits"