### PR TITLE
CHM-29-country-map: fix text issue

### DIFF
--- a/app/views/countries/country-map.html
+++ b/app/views/countries/country-map.html
@@ -218,7 +218,7 @@
                     <div class="col-md-4 text-center ">
                         <span class="rounded label text-white fw-bold bg-party" ng-bind="numParty"></span>
                         <a rel="noopener" translation-url href="/countries/status/party"
-                            class="link-dark text-decoration-none">{{::('countryMapTranslation.partiesToThe'|$translate)}}<span ng-bind="options.protocol"></span>
+                            class="link-dark text-decoration-none">{{::('countryMapTranslation.partiesToThe'|$translate)}} <span ng-bind="options.protocol"></span>
                         </a>
                     </div>
 


### PR DESCRIPTION
### General description
Fixed spacing issue between “the” and “Cartagena”. Same issue was exist on the map for ABSCH.

### Designs
_Link to the related design prototypes (if applicable)_

### Testing instructions
_Provide minimal instructions on how to test this PR._

* Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging
* [ ]  Branch name / PR includes the related Jira ticket Id.
* [ ]  Tests to check core implementation / bug fix added.
* [ ]  All checks in Continuous Integration workflow pass.
* [ ]  Feature functionally tested by reviewer(s).
* [ ]  Code reviewed by reviewer(s).
* [ ]  Documentation updated (README, CHANGELOG...) (if required)

