### PR TITLE
CHM 264--fix html displayed in text field issue

### DIFF
--- a/app/views/forms/view/abs/view-measure.directive.html
+++ b/app/views/forms/view/abs/view-measure.directive.html
@@ -98,7 +98,7 @@
 		<!-- ToDo: will we use this ?, we don't have this in edit  -->
 		<div ng-show="document.registeredMeasuresDescription">
 			<div class="km-value km-pre" compare-val>
-				<km-value-ml value="document.registeredMeasuresDescription" locale="locale"></km-value-ml>
+				<km-value-ml value="document.registeredMeasuresDescription" locale="locale" html></km-value-ml>
 			</div>
 		</div>
 
@@ -133,7 +133,7 @@
 			<div ng-show="document.amendmentsDescription">
 				<label>{{::('viewMeasureT.summaryAmendments'|$translate)}}</label>
 				<div compare-val>
-					<km-value-ml value="document.amendmentsDescription" locales="locale"></km-value-ml>
+					<km-value-ml value="document.amendmentsDescription" locales="locale" html></km-value-ml>
 				</div>
 			</div>
 


### PR DESCRIPTION
### General description
fix CHM 264 issue-  html displayed in text field issue

### Designs
Bug reason:
need to set html attribute to <km-value-ml> in order to parse html text. 

### Testing instructions
1.Select Menu/Submit, create a new "[Legislative, Administrative or Policy Measure (MSR)](http://localhost:2011/register/MSR)".
2. choose "submission form" tab, set "Is this an amendment to previous legislative, administrative or policy measure? " as Yes.  Enter the text in rich text box, then choose any any style like Bold , underlined etc.
3. choose "review" tab, check if the text displayed correctly according to the style selected. 

* Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging
* [ ]  Branch name / PR includes the related Jira ticket Id.
* [ ]  Tests to check core implementation / bug fix added.
* [ ]  All checks in Continuous Integration workflow pass.
* [ ]  Feature functionally tested by reviewer(s).
* [ ]  Code reviewed by reviewer(s).
* [ ]  Documentation updated (README, CHANGELOG...) (if required)

