### PR TITLE
CHM344-include CBD treaty for party non party status

### DIFF
--- a/app/services/common.js
+++ b/app/services/common.js
@@ -28,7 +28,8 @@ export { safeApply, safeDelegate } from '@scbd/angular-vue/src/index.js';
                 var appName = realm.value.replace(/-.*/,'').toLowerCase();
                 var appTreaties = {
                     abs: 'XXVII8b',
-                    bch: 'XXVII8a'
+                    bch: 'XXVII8a',
+                    chm: 'XXVII8'
                 }
                 //==================================================================================
                 this.getReferenceRecordIndex = function(schema, documentId) {


### PR DESCRIPTION
### General description
the party status is defined on https://api.cbd.int/api/v2015/treaties , below the the code of CBD 
{"_id":"560c75ffc99b3c1b0b91c4ba","code":"XXVII8","name":"Convention on Biological Diversity","acronym":"CBD"},

### Designs
In the common service file (app/services/common.js) on line 28 add chm to appTreaties with code "XXVII8", after which all countries in CHm should have a isParty field available. test home page, country profile and search page if there are any console errors.

### Testing instructions
test home page, country profile and search page , no console errors.


