### PR TITLE
CHM347-add getApplicationArticleRealm function

### DIFF
--- a/app/components/kb/article-search.vue
+++ b/app/components/kb/article-search.vue
@@ -62,7 +62,7 @@
       import ArticlesApi from './article-api';
       import "../kb/filters";
       import { formatDate, lstring } from './filters';
-      import { getApplicationArticleRealm } from "../../services/composables/articles.js";
+      import { getRealmArticleTag } from "../../services/composables/articles.js";
 
       const route = useRoute();
       const { t, locale } = useI18n({ messages });
@@ -76,13 +76,14 @@
       const categories = ref([]);
       const search = ref('');
       const articlesCount = ref(0);
+      const realmArticleTag = getRealmArticleTag();
   
       onMounted( async() => {
           categories.value = await loadKbCategories(realm.is('BCH'));
           if (route.value?.params?.search) {
               search.value = route.value.params.search.replace(/"/g, "");
           }         
-          realmTag.value =getApplicationArticleRealm(realm);
+          realmTag.value = realmArticleTag;
           await loadArticles(1);
       });
 

--- a/app/components/kb/article-search.vue
+++ b/app/components/kb/article-search.vue
@@ -62,6 +62,8 @@
       import ArticlesApi from './article-api';
       import "../kb/filters";
       import { formatDate, lstring } from './filters';
+      import { getApplicationArticleRealm } from "../../services/composables/articles.js";
+
       const route = useRoute();
       const { t, locale } = useI18n({ messages });
       const realm = useRealm();
@@ -80,7 +82,7 @@
           if (route.value?.params?.search) {
               search.value = route.value.params.search.replace(/"/g, "");
           }         
-          realmTag.value =getApplicationArticleRealm(realm.value);
+          realmTag.value =getApplicationArticleRealm;
           await loadArticles(1);
       });
 
@@ -90,16 +92,6 @@
           if (adminTags[0] === realm) return adminTags[1];
           else return adminTags[0];
         } else return realm;
-      };
-
-      const getApplicationArticleRealm = (key) => {
-        const realmObj = {
-          'BCH': "bch",
-          'ABS': "absch",
-          'CHM': "chm",
-          'CHM-DEV': "chm"
-        }; 
-        return realmObj[key];
       };
   
       const tagUrl = (tag) => {

--- a/app/components/kb/article-search.vue
+++ b/app/components/kb/article-search.vue
@@ -82,7 +82,7 @@
           if (route.value?.params?.search) {
               search.value = route.value.params.search.replace(/"/g, "");
           }         
-          realmTag.value =getApplicationArticleRealm;
+          realmTag.value =getApplicationArticleRealm(realm);
           await loadArticles(1);
       });
 

--- a/app/components/kb/article-search.vue
+++ b/app/components/kb/article-search.vue
@@ -82,7 +82,7 @@
           if (route.value?.params?.search) {
               search.value = route.value.params.search.replace(/"/g, "");
           }         
-          realmTag.value =getApplicationArticleRealm(realm);
+          realmTag.value =getApplicationArticleRealm;
           await loadArticles(1);
       });
 

--- a/app/components/kb/article-search.vue
+++ b/app/components/kb/article-search.vue
@@ -1,10 +1,10 @@
 <template>
-    <div>
+    <div>    
       <div class="loading" v-if="loading"><i class="fa fa-cog fa-spin fa-lg"></i> {{ t("loading") }}...</div>
       <div v-if="!loading">
         <div class="article-by-tags" v-if="articles">
           <h4>
-            {{t("searchResults") }} <span><small>({{articlesCount}})</small></span>
+            {{t("searchResults") }} <span><small>({{articlesCount}})</small></span>      
           </h4>
           <hr>
           <div v-for="article in articles">
@@ -13,15 +13,15 @@
                 <div class="p-2 bd-highlight" v-if="article.coverImage">
                   <img class="img-fluid img-thumbnail" style="max-height:140px;"
                     v-bind:src="getSizedImage(article.coverImage.url, '300x300')">
-                </div>
+                </div>              
                 <div class="p-2 bd-highlight w-100">
-                  <div class="card-body">
+                  <div class="card-body">                  
                     <span class="badge bg-secondary position-absolute top-0 end-0">
                       {{formatDate(article.meta.createdOn, 'DD MMM YYYY')}}</span>
-  
+                      
                     <h5 class="card-title"><a class="link-dark"
                         :href="`${articleUrl(article, getTag(article.adminTags) )}`">{{lstring(article.title,
-                        $locale)}}</a>
+                        $locale)}}</a>                      
                     </h5>
                     <p v-if="article.summary" class="card-text h-100">
                       <a class="link-dark" :href="`${articleUrl(article, getTag(article.adminTags) )}`">
@@ -79,17 +79,27 @@
           categories.value = await loadKbCategories(realm.is('BCH'));
           if (route.value?.params?.search) {
               search.value = route.value.params.search.replace(/"/g, "");
-          }
-          realmTag.value = realm.is('BCH') ? 'bch' : 'abs';
+          }         
+          realmTag.value =getApplicationArticleRealm(realm.value);
           await loadArticles(1);
       });
 
-      const getTag = (adminTags) => {
-        const realm = realmTag.value === 'BCH' ? 'bch' : 'absch';
+      const getTag = (adminTags) => {       
+        const realm = realmTag.value;
         if (adminTags && adminTags.length >= 2) {
           if (adminTags[0] === realm) return adminTags[1];
           else return adminTags[0];
         } else return realm;
+      };
+
+      const getApplicationArticleRealm = (key) => {
+        const realmObj = {
+          'BCH': "bch",
+          'ABS': "absch",
+          'CHM': "chm",
+          'CHM-DEV': "chm"
+        }; 
+        return realmObj[key];
       };
   
       const tagUrl = (tag) => {

--- a/app/components/kb/articles-by-tag.vue
+++ b/app/components/kb/articles-by-tag.vue
@@ -63,7 +63,7 @@
     import ArticlesApi from './article-api';
     import { formatDate, lstring } from './filters';
     import './filters';
-    import { loadKbCategories, getUrl, getApplicationArticleRealm  } from '../../services/composables/articles.js';
+    import { loadKbCategories, getUrl, getRealmArticleTag  } from '../../services/composables/articles.js';
     import { useRealm } from '../../services/composables/realm.js';
     import {  useRoute } from "@scbd/angular-vue/src/index.js";
     const { t } = useI18n({ messages });
@@ -77,6 +77,7 @@
     let tagDetails =  {};
     let articlesCount = 0;
     let recordsPerPage = 10;
+    const realmArticleTag = getRealmArticleTag();
 
     onMounted(async () => {  
         const paramTag = (route.value?.params?.tag).replace(/"/g, "");
@@ -108,7 +109,7 @@
             articles.value = [];
             const q = {
                 $and: [{
-                        adminTags: getApplicationArticleRealm(realm)                    
+                        adminTags: realmArticleTag                  
                     },
                     {
                         adminTags: {

--- a/app/components/kb/articles-by-tag.vue
+++ b/app/components/kb/articles-by-tag.vue
@@ -63,7 +63,7 @@
     import ArticlesApi from './article-api';
     import { formatDate, lstring } from './filters';
     import './filters';
-    import { loadKbCategories, getUrl, getApplicationArticleRealm  } from '../../services/composables/articles.js';
+    import { loadKbCategories, getUrl } from '../../services/composables/articles.js';
     import { useRealm } from '../../services/composables/realm.js';
     import {  useRoute } from "@scbd/angular-vue/src/index.js";
     const { t } = useI18n({ messages });
@@ -108,7 +108,7 @@
             articles.value = [];
             const q = {
                 $and: [{
-                        adminTags: getApplicationArticleRealm(realm)                    
+                        adminTags: realm.is('BCH') ? 'bch' : 'abs'
                     },
                     {
                         adminTags: {

--- a/app/components/kb/articles-by-tag.vue
+++ b/app/components/kb/articles-by-tag.vue
@@ -63,7 +63,7 @@
     import ArticlesApi from './article-api';
     import { formatDate, lstring } from './filters';
     import './filters';
-    import { loadKbCategories, getUrl } from '../../services/composables/articles.js';
+    import { loadKbCategories, getUrl, getApplicationArticleRealm  } from '../../services/composables/articles.js';
     import { useRealm } from '../../services/composables/realm.js';
     import {  useRoute } from "@scbd/angular-vue/src/index.js";
     const { t } = useI18n({ messages });
@@ -108,7 +108,7 @@
             articles.value = [];
             const q = {
                 $and: [{
-                        adminTags: realm.is('BCH') ? 'bch' : 'abs'
+                        adminTags: getApplicationArticleRealm(realm)                    
                     },
                     {
                         adminTags: {

--- a/app/components/kb/faqs.vue
+++ b/app/components/kb/faqs.vue
@@ -39,7 +39,7 @@
 	import { ref, onMounted } from 'vue';
 	import Paginate from '../common/pagination.vue';
 	import ArticlesApi from './article-api';
-	import { loadKbCategories , getUrl , getApplicationArticleRealm } from '../../services/composables/articles.js'
+	import { loadKbCategories , getUrl } from '../../services/composables/articles.js'
 	import { lstring } from './filters';
 	import { useI18n } from 'vue-i18n';
 	import messages from '../../app-text/components/kb.json';
@@ -73,7 +73,7 @@
 	};
 
 	const getAdminTag = function() {
-		return  getApplicationArticleRealm(realm);	
+		return realm.is('BCH') ? 'bch' : 'absch';
 		
 	};
 
@@ -94,7 +94,7 @@
 
 				faqCount.value = 0;
 				faqs.value = [];
-				const realmTag = getApplicationArticleRealm(realm);    
+				const realmTag = realm.is('BCH') ? 'bch' : 'abs';
 				const q = { 
 					$and : [
 						{ adminTags : { $all : [realmTag, 'faq']}},

--- a/app/components/kb/faqs.vue
+++ b/app/components/kb/faqs.vue
@@ -39,7 +39,7 @@
 	import { ref, onMounted } from 'vue';
 	import Paginate from '../common/pagination.vue';
 	import ArticlesApi from './article-api';
-	import { loadKbCategories , getUrl } from '../../services/composables/articles.js'
+	import { loadKbCategories , getUrl , getApplicationArticleRealm } from '../../services/composables/articles.js'
 	import { lstring } from './filters';
 	import { useI18n } from 'vue-i18n';
 	import messages from '../../app-text/components/kb.json';
@@ -73,7 +73,7 @@
 	};
 
 	const getAdminTag = function() {
-		return realm.is('BCH') ? 'bch' : 'absch';
+		return  getApplicationArticleRealm(realm);	
 		
 	};
 
@@ -94,7 +94,7 @@
 
 				faqCount.value = 0;
 				faqs.value = [];
-				const realmTag = realm.is('BCH') ? 'bch' : 'abs';
+				const realmTag = getApplicationArticleRealm(realm);    
 				const q = { 
 					$and : [
 						{ adminTags : { $all : [realmTag, 'faq']}},

--- a/app/components/kb/faqs.vue
+++ b/app/components/kb/faqs.vue
@@ -39,7 +39,7 @@
 	import { ref, onMounted } from 'vue';
 	import Paginate from '../common/pagination.vue';
 	import ArticlesApi from './article-api';
-	import { loadKbCategories , getUrl , getApplicationArticleRealm } from '../../services/composables/articles.js'
+	import { loadKbCategories , getUrl , getRealmArticleTag  } from '../../services/composables/articles.js'
 	import { lstring } from './filters';
 	import { useI18n } from 'vue-i18n';
 	import messages from '../../app-text/components/kb.json';
@@ -58,6 +58,7 @@
 	// let pageNumber = 1;
 	let pageNumber = ref(1);
 	let recordsPerPage = 10;
+	const realmArticleTag = getRealmArticleTag();
 	
 	onMounted(async ()=>{
 		faqFilterTag.value = route.value?.params?.tag?.replace(/"/g, ""); 
@@ -73,7 +74,7 @@
 	};
 
 	const getAdminTag = function() {
-		return  getApplicationArticleRealm(realm);	
+		return  realmArticleTag;	
 		
 	};
 
@@ -94,7 +95,7 @@
 
 				faqCount.value = 0;
 				faqs.value = [];
-				const realmTag = getApplicationArticleRealm(realm);    
+				const realmTag = realmArticleTag;    
 				const q = { 
 					$and : [
 						{ adminTags : { $all : [realmTag, 'faq']}},

--- a/app/components/kb/latest-faqs.vue
+++ b/app/components/kb/latest-faqs.vue
@@ -16,7 +16,6 @@
 
 	import i18n from '../../app-text/components/kb.json';
 	import ArticlesApi from './article-api';
-	import { getApplicationArticleRealm } from "../../services/composables/articles.js";
 
 	export default {
 		name:'kbLatestFaqs',
@@ -51,7 +50,7 @@
 
 				const q = { 
 					$and : [
-						{ adminTags : { $all : [getApplicationArticleRealm(realm), 'faq' ]}},
+						{ adminTags : { $all : [this.$realm.is('BCH') ? 'bch' : 'abs', 'faq' ]}},
 						{ adminTags : { $all : ['faq']} }
 					]
 				};

--- a/app/components/kb/latest-faqs.vue
+++ b/app/components/kb/latest-faqs.vue
@@ -16,6 +16,7 @@
 
 	import i18n from '../../app-text/components/kb.json';
 	import ArticlesApi from './article-api';
+	import { getApplicationArticleRealm } from "../../services/composables/articles.js";
 
 	export default {
 		name:'kbLatestFaqs',
@@ -50,7 +51,7 @@
 
 				const q = { 
 					$and : [
-						{ adminTags : { $all : [this.$realm.is('BCH') ? 'bch' : 'abs', 'faq' ]}},
+						{ adminTags : { $all : [getApplicationArticleRealm(realm), 'faq' ]}},
 						{ adminTags : { $all : ['faq']} }
 					]
 				};

--- a/app/components/kb/latest-faqs.vue
+++ b/app/components/kb/latest-faqs.vue
@@ -16,7 +16,9 @@
 
 	import i18n from '../../app-text/components/kb.json';
 	import ArticlesApi from './article-api';
-	import { getApplicationArticleRealm } from "../../services/composables/articles.js";
+	import { getRealmArticleTag  } from "../../services/composables/articles.js";
+
+	const realmArticleTag = getRealmArticleTag();
 
 	export default {
 		name:'kbLatestFaqs',
@@ -51,7 +53,7 @@
 
 				const q = { 
 					$and : [
-						{ adminTags : { $all : [getApplicationArticleRealm(realm), 'faq' ]}},
+						{ adminTags : { $all : [ realmArticleTag, 'faq' ]}},
 						{ adminTags : { $all : ['faq']} }
 					]
 				};

--- a/app/components/kb/relevant-articles.vue
+++ b/app/components/kb/relevant-articles.vue
@@ -30,7 +30,7 @@
     
     const { t, locale } = useI18n({ messages });
     const realm = useRealm();
-    const articleRealm = getRealmArticleTag();
+    const articleRealmTag = getRealmArticleTag();
     const props = defineProps({
         tag: { type: String, required: false },
         type:{ type: String, required: false },
@@ -48,7 +48,7 @@
 
     onMounted(async () => {
     let ag = [];
-    ag.push({"$match":{"$and":[{"adminTags": { $all : [articleRealm]}}]}});
+    ag.push({"$match":{"$and":[{"adminTags": { $all : [articleRealmTag]}}]}});
         ag.push({"$match":{"$and":[{"adminTags":props.tag}]}});
         ag.push({"$project" : {[`title`]:1}});
         ag.push({"$limit" : 6});

--- a/app/components/kb/relevant-articles.vue
+++ b/app/components/kb/relevant-articles.vue
@@ -30,7 +30,7 @@
     
     const { t, locale } = useI18n({ messages });
     const realm = useRealm();
-
+    const articleRealm = getApplicationArticleRealm()
     const props = defineProps({
         tag: { type: String, required: false },
         type:{ type: String, required: false },
@@ -47,7 +47,7 @@
 
     onMounted(async () => {
     let ag = [];
-    ag.push({"$match":{"$and":[{"adminTags": { $all : [getApplicationArticleRealm(realm)]}}]}});
+    ag.push({"$match":{"$and":[{"adminTags": { $all : [articleRealm]}}]}});
         ag.push({"$match":{"$and":[{"adminTags":props.tag}]}});
         ag.push({"$project" : {[`title`]:1}});
         ag.push({"$limit" : 6});

--- a/app/components/kb/relevant-articles.vue
+++ b/app/components/kb/relevant-articles.vue
@@ -26,11 +26,11 @@
     import { useRealm } from '../../services/composables/realm.js';
     import { useI18n } from 'vue-i18n';
     import messages from '../../app-text/components/kb.json';
-    import { getApplicationArticleRealm } from "../../services/composables/articles.js";
+    import { getRealmArticleTag } from "../../services/composables/articles.js";
     
     const { t, locale } = useI18n({ messages });
     const realm = useRealm();
-    const articleRealm = getApplicationArticleRealm()
+    const articleRealm = getRealmArticleTag();
     const props = defineProps({
         tag: { type: String, required: false },
         type:{ type: String, required: false },
@@ -44,6 +44,7 @@
     const articles = ref([]);
     const loading = ref(true);
     const articlesApi = new ArticlesApi();
+    c
 
     onMounted(async () => {
     let ag = [];

--- a/app/components/kb/relevant-articles.vue
+++ b/app/components/kb/relevant-articles.vue
@@ -26,6 +26,8 @@
     import { useRealm } from '../../services/composables/realm.js';
     import { useI18n } from 'vue-i18n';
     import messages from '../../app-text/components/kb.json';
+    import { getApplicationArticleRealm } from "../../services/composables/articles.js";
+    
     const { t, locale } = useI18n({ messages });
     const realm = useRealm();
 
@@ -45,7 +47,7 @@
 
     onMounted(async () => {
     let ag = [];
-    ag.push({"$match":{"$and":[{"adminTags": { $all : [realm.is('BCH') ? 'bch' : 'abs' ]}}]}});
+    ag.push({"$match":{"$and":[{"adminTags": { $all : [getApplicationArticleRealm(realm)]}}]}});
         ag.push({"$match":{"$and":[{"adminTags":props.tag}]}});
         ag.push({"$project" : {[`title`]:1}});
         ag.push({"$limit" : 6});

--- a/app/components/kb/relevant-articles.vue
+++ b/app/components/kb/relevant-articles.vue
@@ -26,8 +26,6 @@
     import { useRealm } from '../../services/composables/realm.js';
     import { useI18n } from 'vue-i18n';
     import messages from '../../app-text/components/kb.json';
-    import { getApplicationArticleRealm } from "../../services/composables/articles.js";
-    
     const { t, locale } = useI18n({ messages });
     const realm = useRealm();
 
@@ -47,7 +45,7 @@
 
     onMounted(async () => {
     let ag = [];
-    ag.push({"$match":{"$and":[{"adminTags": { $all : [getApplicationArticleRealm(realm)]}}]}});
+    ag.push({"$match":{"$and":[{"adminTags": { $all : [realm.is('BCH') ? 'bch' : 'abs' ]}}]}});
         ag.push({"$match":{"$and":[{"adminTags":props.tag}]}});
         ag.push({"$project" : {[`title`]:1}});
         ag.push({"$limit" : 6});

--- a/app/services/composables/articles.js
+++ b/app/services/composables/articles.js
@@ -67,7 +67,7 @@ export function shuffleArray (array) {
         .map(({ value }) => value);
 };
 
-export function getApplicationArticleRealm ()  {
+export function getApplicationArticleRealm (realm)  {
         if(realm.is('BCH')) return 'bch';
         if(realm.is('ABS')) return 'absch';
         if(realm.is('CHM')) return 'chm';

--- a/app/services/composables/articles.js
+++ b/app/services/composables/articles.js
@@ -50,19 +50,25 @@ export async function loadKbCategories(isBch, locale) {
             }
 };
 
-        export function getUrl(title, id, tag){
-            const urlTitle = title ? title.trim().replace(/[^a-z0-9]/gi, '-').replace(/-+/g, '-') : undefined;
-            if(title && id){
-                return `kb/tags/${encodeURIComponent(tag)}/${encodeURIComponent(urlTitle)}/${encodeURIComponent(id)}`;
-            } else if (title && !id) {
-                return `kb/tags/${encodeURIComponent(tag)}/${encodeURIComponent(urlTitle)}`;
-            } else if (!title && !id) {
-                return `kb/tags/${encodeURIComponent( tag )}`;
-            }
-        };
+export function getUrl(title, id, tag){
+    const urlTitle = title ? title.trim().replace(/[^a-z0-9]/gi, '-').replace(/-+/g, '-') : undefined;
+    if(title && id){
+        return `kb/tags/${encodeURIComponent(tag)}/${encodeURIComponent(urlTitle)}/${encodeURIComponent(id)}`;
+    } else if (title && !id) {
+        return `kb/tags/${encodeURIComponent(tag)}/${encodeURIComponent(urlTitle)}`;
+    } else if (!title && !id) {
+        return `kb/tags/${encodeURIComponent( tag )}`;
+    }
+};
 
-    export function shuffleArray (array) {
-        return array.map((value) => ({ value, sort: Math.random() * 100 }))
-            .sort((a, b) => a.sort - b.sort)
-            .map(({ value }) => value);
-    };
+export function shuffleArray (array) {
+    return array.map((value) => ({ value, sort: Math.random() * 100 }))
+        .sort((a, b) => a.sort - b.sort)
+        .map(({ value }) => value);
+};
+
+export function getApplicationArticleRealm ()  {
+        if(realm.is('BCH')) return 'bch';
+        if(realm.is('ABS')) return 'absch';
+        if(realm.is('CHM')) return 'chm';
+};

--- a/app/services/composables/articles.js
+++ b/app/services/composables/articles.js
@@ -1,4 +1,6 @@
 import ArticlesApi from '../../components/kb/article-api';
+import { useRealm } from '~/services/composables/realm.js';
+
 const articlesApi = new ArticlesApi();
 
 export async function loadKbCategories(isBch, locale) {
@@ -67,7 +69,10 @@ export function shuffleArray (array) {
         .map(({ value }) => value);
 };
 
-export function getApplicationArticleRealm (realm)  {
+export function getRealmArticleTag ()  {
+    
+        const realm = useRealm();
+
         if(realm.is('BCH')) return 'bch';
         if(realm.is('ABS')) return 'absch';
         if(realm.is('CHM')) return 'chm';

--- a/app/services/composables/articles.js
+++ b/app/services/composables/articles.js
@@ -67,7 +67,7 @@ export function shuffleArray (array) {
         .map(({ value }) => value);
 };
 
-export function getApplicationArticleRealm (realm)  {
+export function getApplicationArticleRealm ()  {
         if(realm.is('BCH')) return 'bch';
         if(realm.is('ABS')) return 'absch';
         if(realm.is('CHM')) return 'chm';

--- a/app/views/forms/view/scbd/view-focalpoint.directive.js
+++ b/app/views/forms/view/scbd/view-focalpoint.directive.js
@@ -1,6 +1,7 @@
 import app from '~/app';
 import template from 'text!./view-focalpoint.directive.html';
 import '~/views/directives/record-options';
+import { getApplicationArticleRealm } from "../../services/composables/articles.js";
 
 app.directive('viewFocalPoint', ['realm', function(realm) {
 	return {
@@ -14,7 +15,7 @@ app.directive('viewFocalPoint', ['realm', function(realm) {
 		},
 		controller: ['$scope','commonjs', '$q', async function ($scope, commonjs, $q) {
 
-			const chFolder = realm.is('BCH') ? 'bch' : 'abs';
+			const chFolder = getApplicationArticleRealm(realm);
 			const { categories } = await import(`../../../../app-data/${chFolder}/focal-point-category.js`);
 
 			$scope.nfpCategory = function(category){

--- a/app/views/forms/view/scbd/view-focalpoint.directive.js
+++ b/app/views/forms/view/scbd/view-focalpoint.directive.js
@@ -1,7 +1,6 @@
 import app from '~/app';
 import template from 'text!./view-focalpoint.directive.html';
 import '~/views/directives/record-options';
-import { getApplicationArticleRealm } from "../../services/composables/articles.js";
 
 app.directive('viewFocalPoint', ['realm', function(realm) {
 	return {
@@ -15,7 +14,7 @@ app.directive('viewFocalPoint', ['realm', function(realm) {
 		},
 		controller: ['$scope','commonjs', '$q', async function ($scope, commonjs, $q) {
 
-			const chFolder = getApplicationArticleRealm(realm);
+			const chFolder = realm.is('BCH') ? 'bch' : 'abs';
 			const { categories } = await import(`../../../../app-data/${chFolder}/focal-point-category.js`);
 
 			$scope.nfpCategory = function(category){


### PR DESCRIPTION
### General description
issue description:
 on https://chm.cbddev.xyz/en/kb check the network calls, the api call is passing abs realm instead of CHM-dev.  the KB pages are vue components, and have hardcoded the realm to ease.


### Designs
create a common function getApplicationArticleRealm  to accomodate chm with absch and bch.
define an object to return correct realm value depends on key( the result of useRealm).
        const realmObj = {
          'BCH': "bch",
          'ABS': "absch",
          'CHM': "chm",
          'CHM-DEV': "chm"
        }; 
now in the local testing enviorment, the result of useRealm  is "CHM_DEV",  so set it also return chm

### Testing instructions
test  kb-search page. 
before change: has 7 records from abs,after change: : has 1 record from chm
<img width="792" alt="image" src="https://github.com/scbd/absch.cbd.int/assets/65098066/1f493d29-baea-424a-9f8f-dad376e18668">

<img width="927" alt="image" src="https://github.com/scbd/absch.cbd.int/assets/65098066/af22e3c2-256d-46ff-ba53-4895f335f925">

