### PR TITLE
CHM362-tour page button issue

### DIFF
--- a/app/views/directives/joyride-template.html
+++ b/app/views/directives/joyride-template.html
@@ -8,13 +8,13 @@ ng-class="{'{{joyride.config.steps[joyride.current].customClass}}':joyride.confi
     </div>
     <div class="jr_buttons">
       <div class="jr_left_buttons">
-        <a class="jr_button jr_skip bg-white" ng-click="joyride.start = false">{{close}}</a>
+        <a class="jr_button jr_skip bg-white" ng-click="joyride.start = false">close</a>
       </div>
   
       <div class="jr_right_buttons">
-        <a class="jr_button jr_prev" ng-click="joyride.prev()" ng-class="{'disabled' : joyride.current === 0}">{{prev}}</a>
-        <a class="jr_button jr_next" ng-click="joyride.next()" ng-if="joyride.current == joyride.config.steps.length-1">{{finish}}</a>
-        <a class="jr_button jr_next" ng-click="joyride.next()" ng-if="joyride.current != joyride.config.steps.length-1">{{next}}</a>
+        <a class="jr_button jr_prev" ng-click="joyride.prev()" ng-class="{'disabled' : joyride.current === 0}">prev</a>
+        <a class="jr_button jr_next" ng-click="joyride.next()" ng-if="joyride.current == joyride.config.steps.length-1">finish</a>
+        <a class="jr_button jr_next" ng-click="joyride.next()" ng-if="joyride.current != joyride.config.steps.length-1">next</a>
       </div>
     </div>
 </div>


### PR DESCRIPTION
### General description
issue description: the button on the tour page does not show any content.

### Designs
the previous code use  variables like {{close}}, but not defined.
so change to a string  close, so that can display directly.

### Testing instructions
use homepage->get start-> tour

### future work:
now the tour will terminate on the step "subfilter". because we has not implemented sub-filter feature in search page yet. to fix that issue , need add  function loadCHMKeywordFilters() in search-directive.js file.

<img width="291" alt="image" src="https://github.com/scbd/absch.cbd.int/assets/65098066/176f88b6-8e36-4412-8e52-e8cd2d731b6d">

