### PR TITLE
CHM364-fix country party status issue in country list 

### DIFF
--- a/app/app-text/views/countries/country-list.json
+++ b/app/app-text/views/countries/country-list.json
@@ -22,6 +22,6 @@
     "partyToCartagena": "Party to the Cartagena Protocol",
     "partyToSuppProtocol": "PARTY TO THE SUPPLEMENTARY PROTOCOL",
     "partyToNagoyaProtocol": "Party to the Nagoya Protocol",
-    "nonPartyToConvention":"Party to the Convention",
-    "PartyToConvention":"Non-Party to the Convention"
+    "nonPartyToConvention":"Non-Party to the Convention",
+    "partyToConvention":"Party to the Convention"
 }


### PR DESCRIPTION
### General description
the reason of this issue, because the wrong statements in json file.

### Testing instructions
test homepage,  
party to convention or nonparty to convention can display correctly

### after fix:
party country:
<img width="437" alt="image" src="https://github.com/scbd/absch.cbd.int/assets/65098066/b0031f58-6290-4465-8eb9-2a5b3d17283b">
non party country:
<img width="275" alt="image" src="https://github.com/scbd/absch.cbd.int/assets/65098066/38604c36-e854-459e-a837-87ad33ba8e92">

