### PR TITLE
Fix forum post navigation and structure

### DIFF
--- a/app/components/forums/post.vue
+++ b/app/components/forums/post.vue
@@ -301,7 +301,6 @@ const toggleReplies = async () => {
 
     const { postId } = props.post;
 
-    console.log('toggleReplies', postId);
 
 
     const postsResponse = await forumsApi.getPosts(postId);

--- a/app/services/jump-to-anchor.js
+++ b/app/services/jump-to-anchor.js
@@ -18,8 +18,11 @@ export default function jumpTo(anchor) {
 
     if(typeof(anchor)=='string') {
         const anchorName = anchor.replace(/^#+/, '');
-        target = $(`a[name=${anchorName}]:first`)[0];
+        target = target || $(`a[id=${anchorName}]:first`)[0];
+        target = target || $(`a[name=${anchorName}]:first`)[0]; // legacy support
     }
+
+    console.log('jumpTo', anchor, target);
 
     if(target) target.scrollIntoView({ behavior:'smooth'});
 }

--- a/app/services/jump-to-anchor.js
+++ b/app/services/jump-to-anchor.js
@@ -22,7 +22,6 @@ export default function jumpTo(anchor) {
         target = target || $(`a[name=${anchorName}]:first`)[0]; // legacy support
     }
 
-    console.log('jumpTo', anchor, target);
 
     if(target) target.scrollIntoView({ behavior:'smooth'});
 }

--- a/app/views/portals/thread-id.vue
+++ b/app/views/portals/thread-id.vue
@@ -29,10 +29,10 @@
         </div>
       </div>
       <h1>{{ lstring(thread.subject) }}</h1>
-      <post :post="thread" class="mb-2" @refresh="load()">
+      <post :post="thread" class="mb-2" @refresh="load()" :showLinkToParent="false">
         <template v-slot:showReplies="{ replies }">
           <em>
-            <a class="anchor-margin" name="replies"></a>
+            <a class="anchor-margin" id="replies" name=""></a>
             <span>
                 <i v-if="replies>0" class="fa" :class="{ 'fa-comment':replies==1, 'fa-comments':replies>1 }"></i>
                 {{ t('linkXReplies', { count: replies }) }}
@@ -84,7 +84,7 @@ const forumUrl = computed(() => {
 
   if (!threadPathPart.test(path)) return null;
 
-  return `${path.replace(threadPathPart, '')}#${encodeURIComponent(props.threadId)}`;
+  return `${path.replace(threadPathPart, '')}#post${encodeURIComponent(props.threadId)}`;
 });
 
 onMounted(async () => {


### PR DESCRIPTION
Updates forum post component to use IDs for anchor links, ensuring consistent navigation within forums and threads.

This change:
- Introduces `post` prefix to anchor IDs for better targeting.
- Modifies the post component to accept `showLinkToSelf` as prop
- Improves the scroll to anchor functionality.
