### PR TITLE
Adds km-pre attribute to reference text

### DIFF
--- a/app/views/forms/view/chm/marine-ebsa.vue
+++ b/app/views/forms/view/chm/marine-ebsa.vue
@@ -86,7 +86,7 @@
                 <legend>{{ t("references") }}</legend>                 
                 <div v-if="document.referenceText">
                     <label>{{ t("references") }} </label>   
-                    <ng v-vue-ng:km-value-ml  :value="document.referenceText" :locales="locale" html ></ng>  
+                    <ng v-vue-ng:km-value-ml  :value="document.referenceText" :locales="locale" html km-pre ></ng>  
                 </div> 
                 <div v-if="document.resources">
                     <label>{{ t("cbdResources") }}</label>


### PR DESCRIPTION
Adds the `km-pre` attribute to the `ng` component displaying reference text.
This ensures that the text is pre-formatted, preserving whitespace
and line breaks in the rendered output, improving readability.
