### PR TITLE
Hides leaflet attribution flag

### DIFF
--- a/app/views/forms/view/chm/leaflet/leaflet.js
+++ b/app/views/forms/view/chm/leaflet/leaflet.js
@@ -4,6 +4,7 @@ var template =
 '<div>'+
 ' <div ref="map" style="height:400px;margin-bottom:10px" class="angular-leaflet-map"></div>'+
 ' <div ref="disclaimer" class="small"></div>'+
+' <style> .leaflet-attribution-flag { display: none !important; } </style>'+
 '</div>';
 
 app.directive("leaflet", ["$http", "$log", "$q", "$timeout", function ($http, $log, $q, $timeout) {


### PR DESCRIPTION
Hides the leaflet attribution flag by adding a CSS rule.
To avoid parties complain.
