### PR TITLE
Hides Leaflet attribution prefix

### DIFF
--- a/app/views/forms/view/chm/leaflet/leaflet.js
+++ b/app/views/forms/view/chm/leaflet/leaflet.js
@@ -4,7 +4,6 @@ var template =
 '<div>'+
 ' <div ref="map" style="height:400px;margin-bottom:10px" class="angular-leaflet-map"></div>'+
 ' <div ref="disclaimer" class="small"></div>'+
-' <style> .leaflet-attribution-flag { display: none !important; } </style>'+
 '</div>';
 
 app.directive("leaflet", ["$http", "$log", "$q", "$timeout", function ($http, $log, $q, $timeout) {
@@ -40,6 +39,8 @@ app.directive("leaflet", ["$http", "$log", "$q", "$timeout", function ($http, $l
                 opt.crs = mapConfig.crs;
 
             var map = new L.Map($el, opt);
+
+            map.attributionControl.setPrefix(false)
 
             if(mapConfig.disclaimer)
                 element.find('[ref="disclaimer"]').html(mapConfig.disclaimer),


### PR DESCRIPTION
Prevents the Leaflet map's default attribution prefix from displaying, resulting in a cleaner map presentation.
