### PR TITLE
Updates deadline field for display

### DIFF
--- a/app/views/forms/view/scbd/view-notification.directive.html
+++ b/app/views/forms/view/scbd/view-notification.directive.html
@@ -21,10 +21,10 @@
 				</a>
 			</span>
 		</div>
-		<div ng-if="document.deadline_s">
+		<div ng-if="document.actionDate_s">
 			<label>Deadline</label>
 			<span class="km-value">
-				{{document.deadline_s| formatDate}}
+				{{document.actionDate_s| formatDate}}
 			</span>
 		</div>
 


### PR DESCRIPTION
Refactors the deadline display to use the `actionDate_s` property instead of `deadline_s`. Ensures consistency with updated data models for notification deadlines.

Relates to CHm-946
