### PR TITLE
Updates Gene Registry 'Traits' Label

### DIFF
--- a/app/app-text/views/reports/bch/registries/view-gene-registry.json
+++ b/app/app-text/views/reports/bch/registries/view-gene-registry.json
@@ -12,7 +12,7 @@
     "export": "Export",
     "recordID": "Record ID",
     "name": "Name",
-    "traits": "Trait(s)",
+    "traits": "Category | Trait(s)",
     "donorOrganism": "Donor organism",
     "function": "Function"
 }


### PR DESCRIPTION
### General description
Updates the display text for the 'traits' field in the gene registry view from 'Trait(s)' to 'Category | Trait(s)'. This change clarifies the content of the column, indicating that it now encompasses both category and trait information, thereby improving user comprehension.

### Designs
_Link to the related design prototypes (if applicable)_

### Testing instructions
*   Navigate to the gene registry view (e.g., a relevant report or registry page that uses `view-gene-registry.json`).
*   Verify that the column header for 'Traits' now displays 'Category | Trait(s)'.
*   Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging
* [x]  Branch name / PR includes the related Jira ticket Id.
* [ ]  Tests to check core implementation / bug fix added.
* [ ]  All checks in Continuous Integration workflow pass.
* [ ]  Feature functionally tested by reviewer(s).
* [ ]  Code reviewed by reviewer(s).
* [ ]  Documentation updated (README, CHANGELOG...) (if required)