### PR TITLE
Calculates Entry Into Force for In-between Parties

### DIFF
--- a/app/services/common.js
+++ b/app/services/common.js
@@ -386,6 +386,15 @@ export { safeApply, safeDelegate } from '@scbd/angular-vue/src/index.js';
                     else
                         country.entryIntoForce = treaties[appTreaties[appName]].party;
 
+                    if(country.CHM.isInbetweenParty)
+                        country.CHM.entryIntoForce = moment.utc(treaties[appTreaties['chm']].deposit).add(90, 'day');
+                    
+                    if(country.ABS.isInbetweenParty)
+                        country.ABS.entryIntoForce = moment.utc(treaties[appTreaties['abs']].deposit).add(90, 'day');
+
+                    if(country.BCH.isInbetweenParty)
+                        country.BCH.entryIntoForce = moment.utc(treaties[appTreaties['bch']].deposit).add(90, 'day');
+                    
                     return country;
                 }                
 

--- a/app/views/countries/country-profile.html
+++ b/app/views/countries/country-profile.html
@@ -15,7 +15,7 @@
                 </h1>
                 <div class="p-3 bg-white">
                 
-                        <div ng-if="vueComponent">
+                        <div ng-if="vueComponent && country">
                             <country-party-status
                                 ng-vue="vueComponent"
                                 :country="country">


### PR DESCRIPTION
### General description
This PR addresses a bug where the `entryIntoForce` date was not correctly calculated for countries identified as 'in-between parties' for the Cartagena Protocol (BCH), Nagoya Protocol (ABS), and CHM. It introduces logic to set the `entryIntoForce` date by adding 90 days to the deposit date for these specific protocols when a country is an 'in-between party'. Additionally, it improves the robustness of the country profile page by ensuring the `country` object is available before rendering the Vue `country-party-status` component, preventing potential rendering issues.

### Designs
_Not applicable_

### Testing instructions
1.  Navigate to a country profile page for a country that is an 'in-between party' for CHM, ABS, or BCH (e.g., if such data exists in your environment).
2.  Verify that the 'Entry Into Force' date for these protocols is correctly calculated as 90 days after their respective deposit dates, when applicable.
3.  Confirm that the `country-party-status` Vue component renders correctly on the country profile page without errors, especially if the `country` data loads asynchronously.

## Checklist before merging
* [x]  Branch name / PR includes the related Jira ticket Id. (CHM-956)
* [ ]  Tests to check core implementation / bug fix added.
* [ ]  All checks in Continuous Integration workflow pass.
* [ ]  Feature functionally tested by reviewer(s).
* [ ]  Code reviewed by reviewer(s).
* [ ]  Documentation updated (README, CHANGELOG...) (if required)