### PR TITLE
Fixes incorrect facet merging and adds National Report filters

### DIFF
--- a/app/views/search/search-directive.js
+++ b/app/views/search/search-directive.js
@@ -1235,18 +1235,18 @@ const searchDirectiveMergeT = mergeTranslationKeys(searchDirectiveT);
                                     };
                         //combine regions and countries facets to match the count.
                         // if any fields has regions than selecting any country from that region should return result
-                        if(facets.regions){
-                            _.forEach(facets.countries, function(con, key){
-                                if(facets.regions[key])
-                                    facets.countries[key] = (facets.countries[key]||0) + facets.regions[key];
-                            })
-                        }
-                        if(facets.countries){
-                            _.forEach(facets.regions, function(reg, key){
-                                if(facets.countries[key])
-                                    facets.regions[key] = (facets.regions[key]||0) + facets.countries[key];
-                            })
-                        }
+                        // if(facets.regions){
+                        //     _.forEach(facets.countries, function(con, key){
+                        //         if(facets.regions[key])
+                        //             facets.countries[key] = (facets.countries[key]||0) + facets.regions[key];
+                        //     })
+                        // }
+                        // if(facets.countries){
+                        //     _.forEach(facets.regions, function(reg, key){
+                        //         if(facets.countries[key])
+                        //             facets.regions[key] = (facets.regions[key]||0) + facets.countries[key];
+                        //     })
+                        // }
 
                         return facets;
                     }

--- a/app/views/search/search-filters/abs-left-menu-filters.js
+++ b/app/views/search/search-filters/abs-left-menu-filters.js
@@ -390,7 +390,12 @@ export const absLeftMenuFilters = {
 		"type": "freeText",
 		"title": absFilters.freeText,
 		"field": "text_EN_txt"
-		}],
+	}],
+	"absNationalReport1" : [{
+		"type": "freeText",
+		"title": absFilters.freeText,
+		"field": "text_EN_txt"
+	}],
 	"resource": [
 		{
 			"type": "freeText",

--- a/app/views/search/search-filters/bch-left-menu-filters.js
+++ b/app/views/search/search-filters/bch-left-menu-filters.js
@@ -217,6 +217,41 @@ export const bchLeftMenuFilters = {
             "field": "text_EN_txt"
         }
     ],
+    "cpbNationalReport1": [
+        {
+            "type": "freeText",
+            "title": bchFilters.freeText,
+            "field": "text_EN_txt"
+        }
+    ],
+    "cpbNationalReport2": [
+        {
+            "type": "freeText",
+            "title": bchFilters.freeText,
+            "field": "text_EN_txt"
+        }
+    ],
+    "cpbNationalReport3": [
+        {
+            "type": "freeText",
+            "title": bchFilters.freeText,
+            "field": "text_EN_txt"
+        }
+    ],
+    "cpbNationalReport4": [
+        {
+            "type": "freeText",
+            "title": bchFilters.freeText,
+            "field": "text_EN_txt"
+        }
+    ],
+    "cpbNationalReport5": [
+        {
+            "type": "freeText",
+            "title": bchFilters.freeText,
+            "field": "text_EN_txt"
+        }
+    ],
     "database": [
         {
             "type": "freeText",


### PR DESCRIPTION
### General description
This pull request addresses an issue with incorrect facet count merging and enhances search capabilities for national reports.

It disables a previous logic that was erroneously combining region and country facet counts, which led to inaccurate results in the search interface.

Additionally, it introduces new free-text search filters for various National Reports, including `absNationalReport1` and `cpbNationalReport1` through `cpbNationalReport5`. These additions, related to CHM-968, improve the ability to perform targeted searches within these specific report categories.

### Designs
_Link to the related design prototypes (if applicable)_

### Testing instructions
*   Verify that region and country facet counts in the search results are now accurate and no longer being incorrectly combined.
*   Test the new free-text search filters for `absNationalReport1` and `cpbNationalReport1` through `cpbNationalReport5` by entering text and confirming that relevant results are returned.
*   Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging
* [x]  Branch name / PR includes the related Jira ticket Id.
* [ ]  Tests to check core implementation / bug fix added.
* [ ]  All checks in Continuous Integration workflow pass.
* [ ]  Feature functionally tested by reviewer(s).
* [ ]  Code reviewed by reviewer(s).
* [ ]  Documentation updated (README, CHANGELOG...) (if required)