### PR TITLE
Adds completion note for CBIs

### DIFF
--- a/app/app-text/views/forms/view/view-capacity-building-initiative.json
+++ b/app/app-text/views/forms/view/view-capacity-building-initiative.json
@@ -42,5 +42,7 @@
     "additionalInformation": "Additional Information",
     "otherRelevantInformation": "Any other relevant information",
     "otherRelevantWebsite": "Other relevant website addresses and/or attached documents",
-    "gbfTargets":"Related Kunming-Montreal Global Biodiversity Framework Target(s)" 
+    "gbfTargets":"Related Kunming-Montreal Global Biodiversity Framework Target(s)",
+    "note":"Note:",    
+    "initiativeComplete":"Based on the indicated “End date”, this capacity development initiative has been completed."
 }

--- a/app/views/forms/view/view-capacity-building-initiative.directive.html
+++ b/app/views/forms/view/view-capacity-building-initiative.directive.html
@@ -65,8 +65,10 @@
 			
 			<label>{{::('viewCdiT.status'|$translate)}}</label>
 			<div ng-class="{'alert alert-info': isInitiativeComplete()}">
-				<strong>{{::('viewCdiT.note'|$translate)}}</strong>
-				{{::('viewCdiT.initiativeComplete'|$translate)}}
+				<span ng-if="isInitiativeComplete()">
+					<strong>{{::('viewCdiT.note'|$translate)}}</strong>
+					{{::('viewCdiT.initiativeComplete'|$translate)}}
+				</span>
 				<div class="km-value" compare-val>
 					<span ng-bind="document.status|term:locale"></span>
 				</div>

--- a/app/views/forms/view/view-capacity-building-initiative.directive.html
+++ b/app/views/forms/view/view-capacity-building-initiative.directive.html
@@ -62,9 +62,14 @@
 		</div>
 
 		<div ng-show="document.status">
+			
 			<label>{{::('viewCdiT.status'|$translate)}}</label>
-			<div class="km-value" compare-val>
-				<span ng-bind="document.status|term:locale"></span>
+			<div ng-class="{'alert alert-info': isInitiativeComplete()}">
+				<strong>{{::('viewCdiT.note'|$translate)}}</strong>
+				{{::('viewCdiT.initiativeComplete'|$translate)}}
+				<div class="km-value" compare-val>
+					<span ng-bind="document.status|term:locale"></span>
+				</div>
 			</div>
 		</div>
 

--- a/app/views/forms/view/view-capacity-building-initiative.directive.js
+++ b/app/views/forms/view/view-capacity-building-initiative.directive.js
@@ -27,20 +27,20 @@ app.directive("viewCapacityBuildingInitiative", ["translationService", function 
 			$scope.isBCH = realm.is('BCH');
 			$scope.isCHM = realm.is('CHM');
 			$scope.onThematicAreasTerms = function(terms){
-			if(($scope.document||{}).cpbThematicAreas){
-				_.forEach(terms, function(item){
-					if(item.broaderTerms.length == 0 || item.broaderTerms == []){
-						var parent =_.find($scope.document.cpbThematicAreas, {identifier: item.identifier});
-						if(parent){
-							terms = _.filter(terms, function(t){
-								return !_.includes(item.narrowerTerms, t.identifier)
-							})
+				if(($scope.document||{}).cpbThematicAreas){
+					_.forEach(terms, function(item){
+						if(item.broaderTerms.length == 0 || item.broaderTerms == []){
+							var parent =_.find($scope.document.cpbThematicAreas, {identifier: item.identifier});
+							if(parent){
+								terms = _.filter(terms, function(t){
+									return !_.includes(item.narrowerTerms, t.identifier)
+								})
+							}
 						}
-					}
-				});
-				return terms;
+					});
+					return terms;
+				}
 			}
-		}
 
 			$scope.onTargetGroupsTerms = function(terms){
 				if(($scope.document||{}).targetGroups){
@@ -82,6 +82,10 @@ app.directive("viewCapacityBuildingInitiative", ["translationService", function 
 
 				return( $scope.hide.indexOf(field) >= 0 ? false : true);
 			};
+
+			$scope.isInitiativeComplete = function(){
+				return $scope.document.endDate && new Date($scope.document.endDate) < new Date();
+			}
 
 		}]
 	};


### PR DESCRIPTION
### General description
Implements a feature to display an informative note when a Capacity Building Initiative (CBI) has passed its indicated end date. This note appears within the status section, making it clear to users that the initiative is completed. New translation keys for the note and message have been added.

### Designs
_Link to the related design prototypes (if applicable)_

### Testing instructions
*   Navigate to the view page of a Capacity Building Initiative.
*   Verify that initiatives with an `endDate` in the past display an "alert-info" box containing a "Note: ... initiative has been completed" message above the status.
*   Confirm that initiatives with an `endDate` in the future or no `endDate` do not display this message.
*   Check that the new translation keys (`note`, `initiativeComplete`) are correctly applied.
*   Apart from the added feature / bug fix, check overall performance, styling...

## Checklist before merging
* [x]  Branch name / PR includes the related Jira ticket Id.
* [ ]  Tests to check core implementation / bug fix added.
* [ ]  All checks in Continuous Integration workflow pass.
* [ ]  Feature functionally tested by reviewer(s).
* [ ]  Code reviewed by reviewer(s).
* [ ]  Documentation updated (README, CHANGELOG...) (if required)

Relates to CHM-893